### PR TITLE
Categories can now be deleted, even when associated with a post

### DIFF
--- a/Tabloid/Models/Category.cs
+++ b/Tabloid/Models/Category.cs
@@ -13,5 +13,6 @@ namespace Tabloid.Models
         [Required]
         [MaxLength(50)]
         public string Name { get; set; }
+        public bool IsDeleted { get; set; } 
     }
 }

--- a/Tabloid/Repositories/CategoryRepository.cs
+++ b/Tabloid/Repositories/CategoryRepository.cs
@@ -43,7 +43,8 @@ namespace Tabloid.Repositories
         public void Delete(int id)
         {
             var category = GetById(id);
-            _context.Category.Remove(category);
+            category.IsDeleted = true;
+            _context.Entry(category).Property("IsDeleted").IsModified = true;
             _context.SaveChanges();
         }
     }

--- a/Tabloid/client/src/components/CategoryList.js
+++ b/Tabloid/client/src/components/CategoryList.js
@@ -27,9 +27,7 @@ export const CategoryList = () => {
         <div className="row justify-content-center">
           <div className="cards-column">
             {categories.map((category) =>
-              category.isDeleted ? (
-                <option key={category.id}></option>
-              ) : (
+              category.isDeleted ? null : (
                 <Category key={category.id} category={category} />
               )
             )}

--- a/Tabloid/client/src/components/CategoryList.js
+++ b/Tabloid/client/src/components/CategoryList.js
@@ -26,9 +26,13 @@ export const CategoryList = () => {
       <div className="categoryContainer">
         <div className="row justify-content-center">
           <div className="cards-column">
-            {categories.map((category) => (
-              <Category key={category.id} category={category} />
-            ))}
+            {categories.map((category) =>
+              category.isDeleted ? (
+                <></>
+              ) : (
+                <Category key={category.id} category={category} />
+              )
+            )}
           </div>
         </div>
       </div>

--- a/Tabloid/client/src/components/CategoryList.js
+++ b/Tabloid/client/src/components/CategoryList.js
@@ -28,7 +28,7 @@ export const CategoryList = () => {
           <div className="cards-column">
             {categories.map((category) =>
               category.isDeleted ? (
-                <></>
+                <option key={category.id}></option>
               ) : (
                 <Category key={category.id} category={category} />
               )

--- a/Tabloid/client/src/components/posts/EditPostForm.js
+++ b/Tabloid/client/src/components/posts/EditPostForm.js
@@ -5,108 +5,119 @@ import { Button, Form } from "reactstrap";
 import { useHistory } from "react-router-dom";
 
 export const EditPostForm = (props) => {
-    const { updatePost } = useContext(PostContext);
-    const { categories, getAllCategories } = useContext(CategoryContext)
-    const [updatedPost, setPost] = useState(props.post);
-    const history = useHistory()
+  const { updatePost } = useContext(PostContext);
+  const { categories, getAllCategories } = useContext(CategoryContext);
+  const [updatedPost, setPost] = useState(props.post);
+  const history = useHistory();
 
-    const handleControlledInputChange = (event) => {
-        const newPost = Object.assign({}, updatedPost);
-        newPost[event.target.name] = event.target.value;
-        setPost(newPost);
-    };
+  const handleControlledInputChange = (event) => {
+    const newPost = Object.assign({}, updatedPost);
+    newPost[event.target.name] = event.target.value;
+    setPost(newPost);
+  };
 
-    useEffect(() => {
-        getAllCategories()
-    }, [])
+  useEffect(() => {
+    getAllCategories();
+  }, []);
 
-    const editPost = () => {
-        updatedPost.categoryId = parseInt(updatedPost.categoryId)
-        console.log(updatedPost)
-        updatePost(updatedPost).then(props.toggle).then(history.push("/posts"));
-    }
+  const editPost = () => {
+    updatedPost.categoryId = parseInt(updatedPost.categoryId);
+    console.log(updatedPost);
+    updatePost(updatedPost).then(props.toggle).then(history.push("/posts"));
+  };
 
-    return (
-        <>
-            <Form className="editPostForm">
-                <fieldset>
-                    <div className="form-group">
-                        <label htmlFor="title">
-                            Title:
-                    <input
-                                type="text"
-                                name="title"
-                                required
-                                autoFocus
-                                className="form-control"
-                                placeholder="Edit post title"
-                                defaultValue={props.post.title}
-                                onChange={handleControlledInputChange}
-                            />
-                            Content:
-                    <input
-                                type="textarea"
-                                name="content"
-                                rows="20"
-                                columns="50"
-                                required
-                                autoFocus
-                                className="form-control"
-                                placeholder="Edit content"
-                                defaultValue={props.post.content}
-                                onChange={handleControlledInputChange}
-                            />
-                            Category:
-                    <select
-                                name="categoryId"
-                                required
-                                className="form-control"
-                                defaultValue={props.post.categoryId}
-                                onChange={handleControlledInputChange}
-                            >
-                                <option value={props.post.categoryId}>{props.post.category.name}</option>
-                                {categories.map((e) => (
-                                    <option key={e.id} value={e.id}>
-                                        {e.name}
-                                    </option>
-                                ))}
-                            </select>
-                            Header Image:
-                     <input
-                                type="text"
-                                name="imageLocation"
-                                className="form-control"
-                                placeholder="Edit post image"
-                                defaultValue={props.post.imageLocation}
-                                onChange={handleControlledInputChange}
-                            />
-                            Published Date:
-                     <input
-                                type="date"
-                                name="publishDateTime"
-                                className="form-control"
-                                placeholder="Edit publish date"
-                                defaultValue={props.post.publishDateTime.split("T")[0]}
-                                onChange={handleControlledInputChange}
-                            />
-                        </label>
-                    </div>
-                </fieldset>
-
-                <Button
-                    color="primary"
-                    onClick={(e) => {
-                        e.preventDefault();
-                        editPost();
-                    }}
+  return (
+    <>
+      <Form className="editPostForm">
+        <fieldset>
+          <div className="form-group">
+            <label htmlFor="title">
+              Title:
+              <input
+                type="text"
+                name="title"
+                required
+                autoFocus
+                className="form-control"
+                placeholder="Edit post title"
+                defaultValue={props.post.title}
+                onChange={handleControlledInputChange}
+              />
+              Content:
+              <input
+                type="textarea"
+                name="content"
+                rows="20"
+                columns="50"
+                required
+                autoFocus
+                className="form-control"
+                placeholder="Edit content"
+                defaultValue={props.post.content}
+                onChange={handleControlledInputChange}
+              />
+              Category:
+              <select
+                name="categoryId"
+                required
+                className="form-control"
+                defaultValue={
+                  props.post.category.isDeleted ? null : props.post.categoryId
+                }
+                onChange={handleControlledInputChange}
+              >
+                <option
+                  value={
+                    props.post.category.isDeleted ? null : props.post.categoryId
+                  }
                 >
-                    Save Updates
-                </Button>
-                <Button onClick={props.toggle}>
-                    Cancel
-                </Button>
-            </Form>
-        </>
-    );
+                  {props.post.category.isDeleted
+                    ? "Select a Category"
+                    : props.post.category.name}
+                </option>
+                {categories.map((e) =>
+                  e.isDeleted ? (
+                    <></>
+                  ) : (
+                    <option key={e.id} value={e.id}>
+                      {e.name}
+                    </option>
+                  )
+                )}
+              </select>
+              Header Image:
+              <input
+                type="text"
+                name="imageLocation"
+                className="form-control"
+                placeholder="Edit post image"
+                defaultValue={props.post.imageLocation}
+                onChange={handleControlledInputChange}
+              />
+              Published Date:
+              <input
+                type="date"
+                name="publishDateTime"
+                className="form-control"
+                placeholder="Edit publish date"
+                defaultValue={props.post.publishDateTime.split("T")[0]}
+                onChange={handleControlledInputChange}
+              />
+            </label>
+          </div>
+        </fieldset>
 
-}
+        <Button
+          color="primary"
+          onClick={(e) => {
+            e.preventDefault();
+            editPost();
+          }}
+        >
+          Save Updates
+        </Button>
+        <Button onClick={props.toggle}>Cancel</Button>
+      </Form>
+    </>
+  );
+};

--- a/Tabloid/client/src/components/posts/EditPostForm.js
+++ b/Tabloid/client/src/components/posts/EditPostForm.js
@@ -22,7 +22,7 @@ export const EditPostForm = (props) => {
 
   const editPost = () => {
     updatedPost.categoryId = parseInt(updatedPost.categoryId);
-    console.log(updatedPost);
+
     updatePost(updatedPost).then(props.toggle).then(history.push("/posts"));
   };
 
@@ -76,9 +76,7 @@ export const EditPostForm = (props) => {
                     : props.post.category.name}
                 </option>
                 {categories.map((e) =>
-                  e.isDeleted ? (
-                    <></>
-                  ) : (
+                  e.isDeleted ? null : (
                     <option key={e.id} value={e.id}>
                       {e.name}
                     </option>

--- a/Tabloid/client/src/components/posts/Post.js
+++ b/Tabloid/client/src/components/posts/Post.js
@@ -2,22 +2,23 @@ import React from "react";
 import { Card, CardImg, CardBody } from "reactstrap";
 import { Link } from "react-router-dom";
 
-
-
 const Post = ({ post }) => {
-    return (
-        <Card className="m-4">
-
-            <CardImg top src={post.imageLocation} alt={post.title} />
-            <CardBody>
-                <Link to={`/posts/${post.id}`}>
-                    <strong>{post.title}</strong>
-                </Link>
-                <p>Author: {post.userProfile.displayName}</p>
-                <p>Category: {post.category.name}</p>
-            </CardBody>
-        </Card>
-    );
+  return (
+    <Card className="m-4">
+      <CardImg top src={post.imageLocation} alt={post.title} />
+      <CardBody>
+        <Link to={`/posts/${post.id}`}>
+          <strong>{post.title}</strong>
+        </Link>
+        <p>Author: {post.userProfile.displayName}</p>
+        {post.category.isDeleted ? (
+          <></>
+        ) : (
+          <p>Category: {post.category.name}</p>
+        )}
+      </CardBody>
+    </Card>
+  );
 };
 
 export default Post;


### PR DESCRIPTION
See if you can go to category manager and delete a category. It just disappear in the browser but still be in your database. 
Then try adding a new one and deleting that one. Same thing should happen. After deleting a category that is associated with some posts head over to the post list. Posts that used to have that category should simply not be showing one now.
If you go to post details and click edit the dropdown should say "Select a Category" and you should be able to assign a new category to that post. 
Try try try to break it!