### PR TITLE
CC-Reactivate Users

### DIFF
--- a/Tabloid/Controllers/UserProfileController.cs
+++ b/Tabloid/Controllers/UserProfileController.cs
@@ -66,6 +66,14 @@ namespace Tabloid.Controllers
             return NoContent();
         }
 
+        [HttpPut("reactivateUser/{id}")]
+        public IActionResult Reactivate(int id)
+        {
+            _userProfileRepository.ReactivateUserProfile(id);
+            return NoContent();
+        }
+
+
         [HttpPut("{id}")]
         public IActionResult Put(int id, UserProfile userProfile)
         {

--- a/Tabloid/Controllers/UserProfileController.cs
+++ b/Tabloid/Controllers/UserProfileController.cs
@@ -35,6 +35,18 @@ namespace Tabloid.Controllers
             return Ok(_userProfileRepository.GetByUserId(id));
         }
 
+        [HttpGet("activeUsers")]
+        public IActionResult GetActiveUsers()
+        {
+            return Ok(_userProfileRepository.GetActiveUsers());
+        }
+
+        [HttpGet("deactivatedUsers")]
+        public IActionResult GetDeactivatedUsers()
+        {
+            return Ok(_userProfileRepository.GetDeactivatedUsers());
+        }
+
         [HttpPost]
         public IActionResult Post(UserProfile userProfile)
         {

--- a/Tabloid/Repositories/UserProfileRepository.cs
+++ b/Tabloid/Repositories/UserProfileRepository.cs
@@ -37,6 +37,22 @@ namespace Tabloid.Repositories
                 .FirstOrDefault(up => up.Id == id);
         }
 
+        public List<UserProfile> GetActiveUsers()
+        {
+            return _context.UserProfile
+               .Include(up => up.UserType)
+               .Where(up => up.IsActive == true)
+               .ToList();
+        }
+
+        public List<UserProfile> GetDeactivatedUsers()
+        {
+            return _context.UserProfile
+               .Include(up => up.UserType)
+               .Where(up => up.IsActive == false)
+               .ToList();
+        }
+
         public void Add(UserProfile userProfile)
         {
             _context.Add(userProfile);

--- a/Tabloid/Repositories/UserProfileRepository.cs
+++ b/Tabloid/Repositories/UserProfileRepository.cs
@@ -66,6 +66,15 @@ namespace Tabloid.Repositories
             _context.Entry(profile).Property("IsActive").IsModified = true;
             _context.SaveChanges();
         }
+
+        public void ReactivateUserProfile(int id)
+        {
+            var profile = GetByUserId(id);
+            profile.IsActive = true;
+            _context.Entry(profile).Property("IsActive").IsModified = true;
+            _context.SaveChanges();
+        }
+
         public void Update(UserProfile userProfile)
         {
             _context.Entry(userProfile).State = EntityState.Modified;

--- a/Tabloid/client/src/components/EditUserProfileForm.js
+++ b/Tabloid/client/src/components/EditUserProfileForm.js
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect } from "react";
-import { Button, Form } from "reactstrap";
+import { Button } from "reactstrap";
 import { UserProfileContext } from "../providers/UserProfileProvider";
 import { UserTypeContext } from "../providers/UserTypeProvider";
 

--- a/Tabloid/client/src/components/post/PostForm.js
+++ b/Tabloid/client/src/components/post/PostForm.js
@@ -8,10 +8,8 @@ export default ({ toggleModal }) => {
 
     const { categories, getAllCategories } = useContext(CategoryContext)
     const userProfile = JSON.parse(sessionStorage.getItem("userProfile"))
-    const form = document.querySelector(".postForm")
     const { addPost } = useContext(PostContext)
     const publicationDate = useRef()
-    const history = useHistory()
     const category = useRef()
     const imageUrl = useRef()
     const content = useRef()

--- a/Tabloid/client/src/components/post/PostForm.js
+++ b/Tabloid/client/src/components/post/PostForm.js
@@ -1,3 +1,9 @@
+/* 
+Author: Calvin Curry
+Component Responsibilty: Renders a form that allows users to create a new
+post by entering in the required information and clicking a button to save it
+*/
+
 import React, { useContext, useEffect, useRef } from "react";
 import { CategoryContext } from "../../providers/CategoryProvider";
 import { PostContext } from "../../providers/PostProvider";

--- a/Tabloid/client/src/components/post/PostList.js
+++ b/Tabloid/client/src/components/post/PostList.js
@@ -1,3 +1,10 @@
+/* 
+Author(s): Calvin Curry, Daniel Hero
+Component Responsibility: Renders a list of user posts. If the ALL POSTS button
+is clicked, the user can view a list of all user posts. If the MY POSTS button is clicked, 
+a list of posts created by that specific user will be rendered.
+*/
+
 import React, { useContext, useEffect, useState } from "react";
 import { PostContext } from "../../providers/PostProvider";
 import { CategoryContext } from "../../providers/CategoryProvider";

--- a/Tabloid/client/src/components/userProfile/UserDeactivationModal.js
+++ b/Tabloid/client/src/components/userProfile/UserDeactivationModal.js
@@ -1,3 +1,8 @@
+/* 
+Author(s): Calvin Curry
+Component Responsibility: Renders a modal that allows Admin users to 
+deactivate an active user profile.
+*/
 import React, { useContext } from 'react';
 import { Modal, ModalBody, ModalFooter, Button } from 'reactstrap';
 import { UserProfileContext } from '../../providers/UserProfileProvider';

--- a/Tabloid/client/src/components/userProfile/UserProfile.js
+++ b/Tabloid/client/src/components/userProfile/UserProfile.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button } from 'reactstrap';
 
-export default ({ user, setClickedUser, setSelectedUser, toggleModal, toggleEditModal }) => {
+export default ({ user, setClickedUser, setSelectedUser, toggleModal, toggleEditModal, isAdmin }) => {
     const currentUser = JSON.parse(sessionStorage.getItem("userProfile"))
     const history = useHistory()
 
@@ -13,7 +13,7 @@ export default ({ user, setClickedUser, setSelectedUser, toggleModal, toggleEdit
             </td>
             <td>{user.displayName}</td>
             <td>{user.userType.name}</td>
-            {currentUser.userType.name === "Admin" &&
+            {isAdmin &&
                 <>
                     <td style={{ color: "blue", cursor: "pointer" }}
                         onClick={() => {

--- a/Tabloid/client/src/components/userProfile/UserProfile.js
+++ b/Tabloid/client/src/components/userProfile/UserProfile.js
@@ -1,3 +1,8 @@
+/* 
+Author(s): Calvin Curry
+Component Responsibility: Provides structure of a user profile that
+renders on the UserProfileList component.
+*/
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button } from 'reactstrap';

--- a/Tabloid/client/src/components/userProfile/UserProfile.js
+++ b/Tabloid/client/src/components/userProfile/UserProfile.js
@@ -1,10 +1,22 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button } from 'reactstrap';
 
-export default ({ user, setClickedUser, setSelectedUser, toggleModal, toggleEditModal, isAdmin }) => {
-    const currentUser = JSON.parse(sessionStorage.getItem("userProfile"))
+export default ({ user, setClickedUser, setSelectedUser, toggleModal, toggleEditModal, isAdmin, isActive }) => {
+    const [activeUser, setActiveUser] = useState(true)
     const history = useHistory()
+
+    const activeUserCheck = () => {
+        if (user.isActive) {
+            setActiveUser(true)
+        } else {
+            setActiveUser(false)
+        }
+    }
+
+    useEffect(() => {
+        activeUserCheck()
+    }, [activeUser])
 
     return (
         <tr key={user.id}>
@@ -13,7 +25,7 @@ export default ({ user, setClickedUser, setSelectedUser, toggleModal, toggleEdit
             </td>
             <td>{user.displayName}</td>
             <td>{user.userType.name}</td>
-            {isAdmin &&
+            {(isAdmin && activeUser) &&
                 <>
                     <td style={{ color: "blue", cursor: "pointer" }}
                         onClick={() => {
@@ -34,6 +46,11 @@ export default ({ user, setClickedUser, setSelectedUser, toggleModal, toggleEdit
                         </Button>
                     </td>
                 </>
+            }
+            {!activeUser &&
+                <td>
+                    <Button>Reactivate</Button>
+                </td>
             }
 
         </tr>

--- a/Tabloid/client/src/components/userProfile/UserProfile.js
+++ b/Tabloid/client/src/components/userProfile/UserProfile.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button } from 'reactstrap';
 
-export default ({ user, setClickedUser, setSelectedUser, toggleModal, toggleEditModal, isAdmin, isActive }) => {
+export default ({ user, setClickedUser, setSelectedUser, toggleModal, toggleEditModal, isAdmin, setDeactivatedUser, toggleReactivationModal }) => {
     const [activeUser, setActiveUser] = useState(true)
     const history = useHistory()
 
@@ -49,7 +49,14 @@ export default ({ user, setClickedUser, setSelectedUser, toggleModal, toggleEdit
             }
             {!activeUser &&
                 <td>
-                    <Button>Reactivate</Button>
+                    <Button
+                        onClick={() => {
+                            setDeactivatedUser(user)
+                            toggleReactivationModal()
+                        }}
+                    >
+                        Reactivate
+                    </Button>
                 </td>
             }
 

--- a/Tabloid/client/src/components/userProfile/UserProfileDetails.js
+++ b/Tabloid/client/src/components/userProfile/UserProfileDetails.js
@@ -1,3 +1,8 @@
+/* 
+Author(s): Calvin Curry
+Component Responsibility: Creates a profile card that
+displays details about a single user. 
+*/
 import React, { useContext, useState, useEffect } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { UserProfileContext } from "../../providers/UserProfileProvider";

--- a/Tabloid/client/src/components/userProfile/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfile/UserProfileList.js
@@ -42,7 +42,7 @@ export default () => {
         <>
             <h1>User Profiles</h1>
             {isAdmin &&
-                <Button onClick={toggleView} >View Deactivated</Button>
+                <Button onClick={toggleView} >{pageView}</Button>
             }
             <Table>
                 <thead>

--- a/Tabloid/client/src/components/userProfile/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfile/UserProfileList.js
@@ -39,8 +39,8 @@ export default () => {
         getAllUserTypes().then(userTypeCheck);
         if (activeProfilesView === true) {
             getActiveUserProfiles()
-                .then(() => setPageView("View Deactivated Users"))
-                .then(() => setHeader("User Profiles"))
+            setHeader("User Profiles")
+            setPageView("View Deactivated Users")
         } else {
             getDeactivatedUserProfiles()
                 .then(() => setPageView("View Active Users"))

--- a/Tabloid/client/src/components/userProfile/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfile/UserProfileList.js
@@ -5,6 +5,7 @@ import { Table, Modal, ModalBody, ModalHeader, Button } from "reactstrap";
 import { EditUserProfileForm } from "../EditUserProfileForm";
 import { UserTypeContext } from '../../providers/UserTypeProvider';
 import UserProfile from './UserProfile';
+import UserReactivationModal from './UserReactivationModal';
 
 
 export default () => {
@@ -15,9 +16,12 @@ export default () => {
     const [modal, setModal] = useState(false)
     const toggleModal = () => setModal(!modal)
     const [clickedUser, setClickedUser] = useState({ id: 0 })
+    const [deactivatedUser, setDeactivatedUser] = useState({ id: 0 })
     const [selectedUser, setSelectedUser] = useState({});
     const [editModal, setEditModal] = useState(false);
+    const [reactivationModal, setReactivationModal] = useState(false)
     const toggleEditModal = () => setEditModal(!editModal);
+    const toggleReactivationModal = () => setReactivationModal(!reactivationModal)
     const toggleView = () => setActiveProfilesView(!activeProfilesView)
     const [isAdmin, setIsAdmin] = useState(false)
     const [pageView, setPageView] = useState("User Profiles")
@@ -67,9 +71,11 @@ export default () => {
                                 key={profile.id}
                                 user={profile}
                                 setClickedUser={setClickedUser}
+                                setDeactivatedUser={setDeactivatedUser}
                                 toggleModal={toggleModal}
                                 setSelectedUser={setSelectedUser}
                                 toggleEditModal={toggleEditModal}
+                                toggleReactivationModal={toggleReactivationModal}
                                 isAdmin={isAdmin}
                             />
                         })
@@ -86,6 +92,11 @@ export default () => {
                 </ModalBody>
             </Modal>
             <UserDeactivationModal modal={modal} toggleModal={toggleModal} clickedUser={clickedUser} />
+            <UserReactivationModal
+                reactivationModal={reactivationModal}
+                toggleReactivationModal={toggleReactivationModal}
+                deactivatedUser={deactivatedUser}
+            />
         </>
     )
 }

--- a/Tabloid/client/src/components/userProfile/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfile/UserProfileList.js
@@ -1,3 +1,8 @@
+/* 
+Author(s): Calvin Curry
+Component Responsibility: Renders a list of active user profiles. Users with the user
+type of Admin can toggle the list and view deactivated profiles as well. 
+*/
 import React, { useContext, useEffect, useState } from 'react';
 import { UserProfileContext } from '../../providers/UserProfileProvider';
 import UserDeactivationModal from './UserDeactivationModal';

--- a/Tabloid/client/src/components/userProfile/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfile/UserProfileList.js
@@ -1,31 +1,51 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { UserProfileContext } from '../../providers/UserProfileProvider';
 import UserDeactivationModal from './UserDeactivationModal';
-import { Table, Modal, ModalBody, ModalHeader } from "reactstrap";
+import { Table, Modal, ModalBody, ModalHeader, Button } from "reactstrap";
 import { EditUserProfileForm } from "../EditUserProfileForm";
 import { UserTypeContext } from '../../providers/UserTypeProvider';
 import UserProfile from './UserProfile';
 
 
 export default () => {
-    const { userProfiles, getAllUserProfiles } = useContext(UserProfileContext)
+    const { userProfiles, getAllUserProfiles, getActiveUserProfiles, getDeactivatedUserProfiles } = useContext(UserProfileContext)
+    const currentUser = JSON.parse(sessionStorage.getItem("userProfile"))
     const { getAllUserTypes } = useContext(UserTypeContext)
     const activeUsers = userProfiles.filter(up => up.isActive === true)
+    const inactiveUsers = userProfiles.filter(up => up.isActive === false)
+    const [activeView, setActiveView] = useState(true)
     const [modal, setModal] = useState(false)
     const toggleModal = () => setModal(!modal)
     const [clickedUser, setClickedUser] = useState({ id: 0 })
     const [selectedUser, setSelectedUser] = useState({});
     const [editModal, setEditModal] = useState(false);
     const toggleEditModal = () => setEditModal(!editModal);
+    const toggleView = () => setActiveView(!activeView)
+    const [isAdmin, setIsAdmin] = useState(false)
+
+    const userTypeCheck = () => {
+        if (currentUser.userType.name === "Admin") {
+            setIsAdmin(true)
+        } else {
+            setIsAdmin(false)
+        }
+    }
 
     useEffect(() => {
-        getAllUserProfiles()
-            .then(() => getAllUserTypes())
-    }, [])
+        getAllUserTypes().then(userTypeCheck);
+        if (activeView === true) {
+            getActiveUserProfiles()
+        } else {
+            getDeactivatedUserProfiles()
+        }
+    }, [activeView])
 
     return (
         <>
             <h1>User Profiles</h1>
+            {isAdmin &&
+                <Button onClick={toggleView} >View Deactivated</Button>
+            }
             <Table>
                 <thead>
                     <tr>
@@ -38,7 +58,7 @@ export default () => {
                 </thead>
                 <tbody>
                     {
-                        activeUsers.map(profile => {
+                        userProfiles.map(profile => {
                             return <UserProfile
                                 key={profile.id}
                                 user={profile}

--- a/Tabloid/client/src/components/userProfile/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfile/UserProfileList.js
@@ -20,6 +20,8 @@ export default () => {
     const toggleEditModal = () => setEditModal(!editModal);
     const toggleView = () => setActiveProfilesView(!activeProfilesView)
     const [isAdmin, setIsAdmin] = useState(false)
+    const [pageView, setPageView] = useState("User Profiles")
+    const [header, setHeader] = useState("")
 
     const userTypeCheck = () => {
         if (currentUser.userType.name === "Admin") {
@@ -33,16 +35,20 @@ export default () => {
         getAllUserTypes().then(userTypeCheck);
         if (activeProfilesView === true) {
             getActiveUserProfiles()
+                .then(() => setPageView("View Deactivated Users"))
+                .then(() => setHeader("User Profiles"))
         } else {
             getDeactivatedUserProfiles()
+                .then(() => setPageView("View Active Users"))
+                .then(() => setHeader("Deactivated Users"))
         }
-    }, [activeProfilesView])
+    }, [activeProfilesView, pageView])
 
     return (
         <>
-            <h1>User Profiles</h1>
+            <h1>{header}</h1>
             {isAdmin &&
-                <Button onClick={toggleView} >{pageView}</Button>
+                <Button onClick={toggleView}>{pageView}</Button>
             }
             <Table>
                 <thead>

--- a/Tabloid/client/src/components/userProfile/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfile/UserProfileList.js
@@ -8,7 +8,7 @@ import UserProfile from './UserProfile';
 
 
 export default () => {
-    const { userProfiles, getAllUserProfiles, getActiveUserProfiles, getDeactivatedUserProfiles } = useContext(UserProfileContext)
+    const { userProfiles, getActiveUserProfiles, getDeactivatedUserProfiles } = useContext(UserProfileContext)
     const currentUser = JSON.parse(sessionStorage.getItem("userProfile"))
     const { getAllUserTypes } = useContext(UserTypeContext)
     const [activeProfilesView, setActiveProfilesView] = useState(true)

--- a/Tabloid/client/src/components/userProfile/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfile/UserProfileList.js
@@ -11,16 +11,14 @@ export default () => {
     const { userProfiles, getAllUserProfiles, getActiveUserProfiles, getDeactivatedUserProfiles } = useContext(UserProfileContext)
     const currentUser = JSON.parse(sessionStorage.getItem("userProfile"))
     const { getAllUserTypes } = useContext(UserTypeContext)
-    const activeUsers = userProfiles.filter(up => up.isActive === true)
-    const inactiveUsers = userProfiles.filter(up => up.isActive === false)
-    const [activeView, setActiveView] = useState(true)
+    const [activeProfilesView, setActiveProfilesView] = useState(true)
     const [modal, setModal] = useState(false)
     const toggleModal = () => setModal(!modal)
     const [clickedUser, setClickedUser] = useState({ id: 0 })
     const [selectedUser, setSelectedUser] = useState({});
     const [editModal, setEditModal] = useState(false);
     const toggleEditModal = () => setEditModal(!editModal);
-    const toggleView = () => setActiveView(!activeView)
+    const toggleView = () => setActiveProfilesView(!activeProfilesView)
     const [isAdmin, setIsAdmin] = useState(false)
 
     const userTypeCheck = () => {
@@ -33,12 +31,12 @@ export default () => {
 
     useEffect(() => {
         getAllUserTypes().then(userTypeCheck);
-        if (activeView === true) {
+        if (activeProfilesView === true) {
             getActiveUserProfiles()
         } else {
             getDeactivatedUserProfiles()
         }
-    }, [activeView])
+    }, [activeProfilesView])
 
     return (
         <>
@@ -66,6 +64,7 @@ export default () => {
                                 toggleModal={toggleModal}
                                 setSelectedUser={setSelectedUser}
                                 toggleEditModal={toggleEditModal}
+                                isAdmin={isAdmin}
                             />
                         })
                     }

--- a/Tabloid/client/src/components/userProfile/UserReactivationModal.js
+++ b/Tabloid/client/src/components/userProfile/UserReactivationModal.js
@@ -1,3 +1,8 @@
+/* 
+Author(s): Calvin Curry
+Component Responsibility: Renders a modal that allows Admin users to 
+reactivate a currently deactivated user profile.
+*/
 import React, { useContext } from 'react';
 import { Modal, ModalBody, ModalFooter, Button } from 'reactstrap';
 import { UserProfileContext } from '../../providers/UserProfileProvider';

--- a/Tabloid/client/src/components/userProfile/UserReactivationModal.js
+++ b/Tabloid/client/src/components/userProfile/UserReactivationModal.js
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react';
+import { Modal, ModalBody, ModalFooter, Button } from 'reactstrap';
+import { UserProfileContext } from '../../providers/UserProfileProvider';
+
+
+export default ({ reactivationModal, toggleReactivationModal, deactivatedUser }) => {
+    const { reactivateUser } = useContext(UserProfileContext)
+    const reactivateAccount = (profile) => {
+        reactivateUser(profile)
+    }
+    return (
+        <Modal isOpen={reactivationModal} toggle={toggleReactivationModal} >
+            <ModalBody>
+                Are you sure you want to re-activate {deactivatedUser.fullName}?
+            </ModalBody>
+            <ModalFooter>
+                <Button color="primary" onClick={() => {
+                    reactivateAccount(deactivatedUser)
+                    toggleReactivationModal()
+                }}>
+                    Yes
+                </Button>
+                <Button onClick={toggleReactivationModal}>Cancel</Button>
+            </ModalFooter>
+        </Modal>
+    )
+}

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -142,13 +142,32 @@ export function UserProfileProvider(props) {
         },
       }).then((resp) => {
         if (resp.ok) {
-          getAllUserProfiles();
+          getActiveUserProfiles();
         } else {
           throw new Error("Unauthorized");
         }
       })
     )
   };
+
+  const reactivateUser = (userProfile) => {
+    return getToken().then((token) =>
+      fetch(`${apiUrl}/reactivateUser/${userProfile.id}`, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }).then((resp) => {
+        if (resp.ok) {
+          getDeactivatedUserProfiles();
+        } else {
+          throw new Error("Unauthorized");
+        }
+      })
+    )
+  };
+
+
 
   const updateUser = (userProfile) =>
     getToken().then((token) =>
@@ -175,6 +194,7 @@ export function UserProfileProvider(props) {
         userProfiles,
         getUserProfileByUserId,
         deactivateUser,
+        reactivateUser,
         updateUser,
         getActiveUserProfiles,
         getDeactivatedUserProfiles

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -1,3 +1,7 @@
+/* 
+Author(s): Calvin Curry
+Component Responsibility: Houses functions that extract data from the API
+*/
 import React, { useState, useEffect, createContext } from "react";
 import { Spinner } from "reactstrap";
 import * as firebase from "firebase/app";

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -94,6 +94,32 @@ export function UserProfileProvider(props) {
     );
   };
 
+  const getActiveUserProfiles = () => {
+    return getToken().then((token) =>
+      fetch(`${apiUrl}/activeUsers`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+        .then((resp) => resp.json())
+        .then(setUserProfiles)
+    );
+  };
+
+  const getDeactivatedUserProfiles = () => {
+    return getToken().then((token) =>
+      fetch(`${apiUrl}/deactivatedUsers`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+        .then((resp) => resp.json())
+        .then(setUserProfiles)
+    );
+  };
+
   const saveUser = (userProfile) => {
     return getToken().then((token) =>
       fetch(apiUrl, {
@@ -150,6 +176,8 @@ export function UserProfileProvider(props) {
         getUserProfileByUserId,
         deactivateUser,
         updateUser,
+        getActiveUserProfiles,
+        getDeactivatedUserProfiles
       }}
     >
       {isFirebaseReady ? (


### PR DESCRIPTION
**CHANGES**
- Created a modal component for reactivating users and added it to UserProfileList
- Added a Reactivation button to UserProfile
- Added state variables to control  the reactivation modal
- Added reactivation methods to the UserProfile repository, controller, and provider

**TESTING**
- Run the app from VS and VSCode
- Login as an ADMIN user
- Navigate to the User Profiles page
- Click the Deactivate button on a user profile
- Once you've confirmed deactivation, click the "View Deactivated Users" button at the top left of the page. 
- Ensure that you now see a header that reads "Deactivated Users" and can now view the user profile that you deactivated. 
- Click the Reactivate button, then click "yes" in the modal to confirm.
- Click the "View Active Users" button at the top left to return to the page with the header "User Profiles"
- Ensure that the reactivated user appears in the list of user profiles on this page. 
- Logout and log back in as an Author user and verify that you cannot see the button to view deactivated profiles, or the deactivate and edit buttons.